### PR TITLE
catalog: add dsh-bash-terminal (Windows multi-terminal shell + interactive PTY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-suite
 
 ![GitHub stars](https://img.shields.io/github/stars/whyihaveyou/dsh-suite?style=flat-square&color=facc15)
-![Plugins](https://img.shields.io/badge/plugins-167-facc15?style=flat-square)
+![Plugins](https://img.shields.io/badge/plugins-168-facc15?style=flat-square)
 ![Daily compat](https://img.shields.io/github/actions/workflow/status/whyihaveyou/dsh-suite/compat.yml?branch=main&label=daily-compat-check&style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-3b82f6?style=flat-square)
 
@@ -116,6 +116,7 @@ npm create dsh-plugin@latest my-plugin
 | [sandbox-nono](https://github.com/omdsh-dev/sandbox-nono) | 0 | ⚪ unknown | nono sandbox support |
 | [web-components](https://github.com/omdsh-dev/web-components) | 0 | ⚪ unknown | web-components support |
 | [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) | 0 | ⚪ unknown | Wave-RAG retrieval for Zotero paper library |
+| [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | 0 | ⚪ unknown | One shell tool running PowerShell / Git Bash / WSL on Windows, with a user-chosen default terminal in DSH settings. |
 
 ### 🎨 UI
 
@@ -256,7 +257,7 @@ npm create dsh-plugin@latest my-plugin
 | [plugin-notify](https://github.com/whyihaveyou/dsh-suite) | 0 | 🟢 ok | Send IM webhook + local notifications on turn completion / error / approval (Feishu / WeCom / DingTalk / Slack / Discord / custom… |
 
 > Badges: 🟢 compatible · 🔴 broken · ⚪ unverified · ⚫ unmaintained.
-> 167 entries total, grouped by category, sorted by ⭐ within each. Schema dictionary: [docs/catalog-schema.md](docs/catalog-schema.md).
+> 168 entries total, grouped by category, sorted by ⭐ within each. Schema dictionary: [docs/catalog-schema.md](docs/catalog-schema.md).
 <!-- CATALOG:END -->
 
 ## Compatibility

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # dsh-suite
 
 ![GitHub stars](https://img.shields.io/github/stars/whyihaveyou/dsh-suite?style=flat-square&color=facc15)
-![Plugins](https://img.shields.io/badge/plugins-167-facc15?style=flat-square)
+![Plugins](https://img.shields.io/badge/plugins-168-facc15?style=flat-square)
 ![Daily compat](https://img.shields.io/github/actions/workflow/status/whyihaveyou/dsh-suite/compat.yml?branch=main&label=daily-compat-check&style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-3b82f6?style=flat-square)
 
@@ -116,6 +116,7 @@ npm create dsh-plugin@latest my-plugin
 | [sandbox-nono](https://github.com/omdsh-dev/sandbox-nono) | 0 | ⚪ unknown | nono 沙盒支持 |
 | [web-components](https://github.com/omdsh-dev/web-components) | 0 | ⚪ unknown | web-components 支持 |
 | [zotero-wave-rag](https://github.com/Fisfzy/zotero-wave-rag) | 0 | ⚪ unknown | 面向 Zotero 论文库的浪潮式 RAG 检索 |
+| [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) | 0 | ⚪ unknown | 一个 shell 工具：在 Windows 上统一执行 PowerShell / Git Bash / WSL 命令，默认终端由用户在 DSH 设置中选择。 |
 
 ### 🎨 界面
 
@@ -256,7 +257,7 @@ npm create dsh-plugin@latest my-plugin
 | [plugin-notify](https://github.com/whyihaveyou/dsh-suite) | 0 | 🟢 ok | 回合完成 / 出错 / 待审批时，把通知推到 IM webhook（飞书 / 企业微信 / 钉钉 / Slack / Discord / 自定义）+ 本机系统通知。 |
 
 > 徽章含义：🟢 兼容 · 🔴 不兼容 · ⚪ 未实测 · ⚫ 弃坑。
-> 共 167 个条目，按分类分表、类内按 ⭐ 降序。收录 / 字段词典见 [docs/catalog-schema.md](docs/catalog-schema.md)。
+> 共 168 个条目，按分类分表、类内按 ⭐ 降序。收录 / 字段词典见 [docs/catalog-schema.md](docs/catalog-schema.md)。
 <!-- CATALOG:END -->
 
 ## 兼容性

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -4,7 +4,7 @@
     "generated_at": "2026-08-13T23:47:41+08:00",
     "source": "research/plugins-catalog.json (Eco-Scout, 222 entries verified)",
     "totals": {
-      "plugins": 167,
+      "plugins": 168,
       "watchlist": 57
     },
     "category_mapping": {
@@ -5389,6 +5389,45 @@
       "featured": true,
       "isOfficialBeta": false,
       "language": "TypeScript",
+      "sourceNote": ""
+    },
+    {
+      "id": "dsh-bash-terminal",
+      "name": "dsh-bash-terminal",
+      "npm": "dsh-bash-terminal",
+      "repo": "MAXeaglet/dsh-bash-terminal",
+      "url": "https://github.com/MAXeaglet/dsh-bash-terminal",
+      "category": "tools",
+      "description": {
+        "en": "One shell tool running PowerShell / Git Bash / WSL on Windows, with a user-chosen default terminal in DSH settings.",
+        "zh": "一个 shell 工具：在 Windows 上统一执行 PowerShell / Git Bash / WSL 命令，默认终端由用户在 DSH 设置中选择。"
+      },
+      "author": "MAXeaglet",
+      "stars": 0,
+      "license": "MIT",
+      "tags": [
+        "shell",
+        "terminal",
+        "windows",
+        "wsl",
+        "git-bash",
+        "pty"
+      ],
+      "dsh": {
+        "minVersion": "0.1.0-rc.6",
+        "peerCordis": "^4.0.1",
+        "node": ">=20"
+      },
+      "compat": {
+        "status": "unknown",
+        "dshVersion": "",
+        "lastVerified": "",
+        "note": ""
+      },
+      "install": "",
+      "featured": false,
+      "isOfficialBeta": false,
+      "language": "JavaScript",
       "sourceNote": ""
     }
   ],


### PR DESCRIPTION
## Summary

Adds [dsh-bash-terminal](https://github.com/MAXeaglet/dsh-bash-terminal) to the catalog (category: tools). Closes/relates to issue #1.

## Plugin highlights

- One  tool running PowerShell / Git Bash / WSL on Windows; the default terminal is chosen by the user in the DSH Web settings (AI cannot override).
- Official seams throughout:  (process-tree termination, spill),  +  (confine, fail-closed, official /justification escalation and denial markers), jobs registry.
- Interactive  tool: persistent real-PTY sessions over  (node-pty) — open/send/read/signal/close, sessions managed as background jobs with idle auto-close.
- npm  (0.2.3 published; 0.3.x pending 2FA publish), peerDependencies complete (@deepseek-ai/cordis ^4.0.1, dsh packages ^0.1.0-rc.6), so the static peer check can report .
- CI: GitHub Actions (windows-latest) runs unit / apply / client / terminal (real node-pty) suites.

## Verification

- 
> dsh-suite@0.1.0 gen:readme
> node scripts/gen-readme.mjs

gen-readme: OK
  data/plugins.json: 168 plugins (+57 watchlist), 15 featured
  README.md          -> 183 table rows (183 expected)
  README.zh-CN.md    -> 183 table rows (183 expected) regenerated both README tables (183 rows); entry  (not yet verified by the daily compat CI).
- 
> dsh-suite@0.1.0 compat:check:layer1
> node scripts/compat-check.mjs --layers 1

compat-check: latest DSH = ?, cordis = ?, node = 24.16.0

Layer 1 (static peer) — 225 entries total (catalog 168 + watchlist 57):
  catalog  : total=168 unavailable=168
  watchlist: total=57 unavailable=57

Report written to D:\WorkSpace\tmp\dsh-suite\data\compat-report.json will verify the peer declaration on merge.