### PR TITLE
data: verify Codex Connect npm and DSH rc.6 metadata

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -233,7 +233,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-backup-sync](https://github.com/csiroqa/dsh-backup-sync) | 1 | ⚪ unknown | DeepSeek Harness（DSH）备份/恢复 + 跨机同步插件：本地快照、WebDAV 推送/拉取、自动备份与失效归档清理。Snapshot backup, restore and cross-machine sync plugin for Deep… |
 | [dsh-auto](https://github.com/simon300000/dsh-auto) | 4 | ⚪ unknown | dsh Auto Approve |
 | [dsh-annotate](https://github.com/BrambleXu/dsh-annotate) | 6 | ⚪ unknown | Visual browser element annotation for DeepSeek Harness, capturing DOM, styles, accessibility data, comments, and viewport screens… |
-| [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | 18 | ⚪ unknown | ChatGPT OAuth and Codex models for DeepSeek Harness. |
+| [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | 18 | 🟢 ok | ChatGPT OAuth and Codex models for DeepSeek Harness. |
 | [DSH-Decktop](https://github.com/JustGenius-s/DSH-Decktop) | 21 | ⚪ unknown | DSH-Decktop |
 | [dsh-cad-review](https://github.com/dongsheng123132/dsh-cad-review) | 3 | ⚪ unknown | Evidence-first ASCII DXF inspection and deterministic CAD rule review for DeepSeek Harness |
 | [dsh-xai](https://github.com/MirDie/dsh-xai) | 2 | ⚪ unknown | xAI Grok SuperGrok / X Premium OAuth for DeepSeek Harness |

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-backup-sync](https://github.com/csiroqa/dsh-backup-sync) | 1 | ⚪ unknown | dsh-backup-sync — DSH 插件（工具） |
 | [dsh-auto](https://github.com/simon300000/dsh-auto) | 4 | ⚪ unknown | dsh-auto — DSH 插件（工具） |
 | [dsh-annotate](https://github.com/BrambleXu/dsh-annotate) | 6 | ⚪ unknown | dsh-annotate — DSH 插件（工具） |
-| [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | 18 | ⚪ unknown | dsh-codex-connect — DSH 插件（工具） |
+| [dsh-codex-connect](https://github.com/franksong2702/dsh-codex-connect) | 18 | 🟢 ok | 通过 ChatGPT OAuth 在 DeepSeek Harness 中使用 OpenAI Codex 模型。 |
 | [DSH-Decktop](https://github.com/JustGenius-s/DSH-Decktop) | 21 | ⚪ unknown | DSH-Decktop — DSH 插件（工具） |
 | [dsh-cad-review](https://github.com/dongsheng123132/dsh-cad-review) | 3 | ⚪ unknown | dsh-cad-review — DSH 插件（工具） |
 | [dsh-xai](https://github.com/MirDie/dsh-xai) | 2 | ⚪ unknown | dsh-xai — DSH 插件（工具） |

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -18503,30 +18503,30 @@
   {
    "id": "dsh-codex-connect",
    "name": "dsh-codex-connect",
-   "npm": null,
+   "npm": "dsh-codex-connect",
    "repo": "franksong2702/dsh-codex-connect",
    "url": "https://github.com/franksong2702/dsh-codex-connect",
    "category": "tools",
    "description": {
     "en": "ChatGPT OAuth and Codex models for DeepSeek Harness.",
-    "zh": "dsh-codex-connect — DSH 插件（工具）"
+    "zh": "通过 ChatGPT OAuth 在 DeepSeek Harness 中使用 OpenAI Codex 模型。"
    },
    "author": "franksong2702",
    "stars": 18,
    "license": "Apache-2.0",
    "tags": [],
    "dsh": {
-    "minVersion": "",
-    "peerCordis": "",
-    "node": ""
+    "minVersion": "0.1.0-rc.6",
+    "peerCordis": "^4.0.1-rc.1",
+    "node": "^22.19.0 || >=24.0.0"
    },
    "compat": {
-    "status": "unknown",
-    "dshVersion": "",
-    "lastVerified": "",
+    "status": "ok",
+    "dshVersion": "0.1.0-rc.6",
+    "lastVerified": "2026-08-17",
     "note": ""
    },
-   "install": "",
+   "install": "dsh plugin --profile web add dsh-codex-connect@alpha",
    "featured": false,
    "isOfficialBeta": false,
    "language": "TypeScript",


### PR DESCRIPTION
## Summary

- link the existing `dsh-codex-connect` catalog entry to its verified npm package
- record the tested DSH `0.1.0-rc.6`, Cordis, and Node compatibility contract
- replace the placeholder Chinese description and add the plugin's documented install command
- regenerate both catalog READMEs from `data/plugins.json`

## Verification

- `node scripts/verify-repo.mjs` — all five checks passed
- `git diff --cached --check` — passed
- npm registry: `dsh-codex-connect@0.1.0-alpha.4.8` publishes the recorded Cordis/Node ranges and exact `0.1.0-rc.6` DSH plugin API peers
- isolated DSH compatibility canary: https://github.com/franksong2702/dsh-codex-connect/actions/runs/32007229111

## Compatibility note

The catalog's current Layer 1 checker exits successfully but reports this package as `unknown` because its minimal range parser does not parse the valid prerelease range `^4.0.1-rc.1`. The `ok` status here is backed by the isolated DSH `0.1.0-rc.6` install/config validation above. This PR intentionally does not change the shared compatibility checker.

## Out of scope

- no catalog schema or compatibility-checker changes
- no changes to other plugin entries
- no featured/evidence/risk edits
