### PR TITLE
catalog: dsh-trace-compare 补中文描述与 npm/install 信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,7 @@ npm create dsh-plugin@latest my-plugin
 | [MemOS](https://github.com/MemTensor/MemOS) | 10832 | ⚪ unknown | untranslated |
 | [dsh-plugin-bridge](https://github.com/Totoro-qaq/dsh-plugin-bridge) | 35 | ⚪ unknown | untranslated |
 | [dsh-eli-mode](https://github.com/CeilCelia/dsh-eli-mode) | 5 | 🟢 ok | untranslated |
-| [dsh-trace-compare](https://github.com/lamost423/dsh-trace-compare) | 35 | ⚪ unknown | untranslated |
+| [dsh-trace-compare](https://github.com/lamost423/dsh-trace-compare) | 35 | ⚪ unknown | 执行轨迹可视化：主干、失败支路、折返点与子代理支路画在同一根墙钟时间轴上；支持上传 1–2 个 session log 同轴对比，或在会话页签实时看迷宫生长。 |
 | [dsh-sandbox-escalation-fix](https://github.com/JUSTMONIKA2022/dsh-sandbox-escalation-fix) | 9 | ⚪ unknown | untranslated |
 | [dsh-nested-followups](https://github.com/sluminositys/dsh-nested-followups) | 12 | 🟢 ok | untranslated |
 | [dsh-turn-delete](https://github.com/hanshenmesen/dsh-turn-delete) | 20 | 🟢 ok | untranslated |

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -60379,13 +60379,13 @@
   {
    "id": "dsh-trace-compare",
    "name": "dsh-trace-compare",
-   "npm": null,
+   "npm": "dsh-trace-compare",
    "repo": "lamost423/dsh-trace-compare",
    "url": "https://github.com/lamost423/dsh-trace-compare",
    "category": "session",
    "description": {
     "en": "Trace Compare & Live Maze for DeepSeek Harness: visualize agent exploration (main path, detours, backtracks) from session logs or live sess…",
-    "zh": "untranslated"
+    "zh": "执行轨迹可视化：主干、失败支路、折返点与子代理支路画在同一根墙钟时间轴上；支持上传 1–2 个 session log 同轴对比，或在会话页签实时看迷宫生长。"
    },
    "author": "lamost423",
    "stars": 35,
@@ -60403,7 +60403,7 @@
     "lastVerified": "",
     "note": ""
    },
-   "install": "",
+   "install": "dsh plugin --profile web add dsh-trace-compare",
    "featured": false,
    "isOfficialBeta": false,
    "language": "HTML",


### PR DESCRIPTION
我是 `lamost423/dsh-trace-compare` 的作者。目录里这条现在 `description.zh` 是 untranslated，按收录标准第 4 条补上中文一句话描述（79 字符 ≤140）；顺带补两个可核实的事实字段：npm 包名 `dsh-trace-compare`（已发布 v0.5.0，界面中英双语）与安装命令。

- 只改 `data/plugins.json` 这一条 + `npm run gen:readme` 重新生成的表格行，未手改任何表格
- `compat.status` 保持 `unknown` 未动（没在你们的验证环境实测过，遵守诚实规则）

I'm the author of dsh-trace-compare; this fills the missing `description.zh` for the existing auto-imported entry (per inclusion criterion #4), plus the factual `npm`/`install` fields. Tables regenerated via `npm run gen:readme`; `compat.status` left `unknown` untouched.