### PR TITLE
catalog: add dsh-tmux-cc

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 # dsh-suite
 
 ![GitHub stars](https://img.shields.io/github/stars/whyihaveyou/dsh-suite?style=flat-square&color=facc15)
-![Plugins](https://img.shields.io/badge/plugins-1764-facc15?style=flat-square)
+![Plugins](https://img.shields.io/badge/plugins-1765-facc15?style=flat-square)
 ![Daily compat](https://img.shields.io/github/actions/workflow/status/whyihaveyou/dsh-suite/compat.yml?branch=main&label=daily-compat-check&style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-3b82f6?style=flat-square)
 
@@ -932,6 +932,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-custom-background](https://github.com/StarryHui/dsh-custom-background) | 8 | ⚪ unknown | DSH 自定义 WebUI 背景插件 |
 | [dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) | 8 | ⚪ unknown | Git Bash tool plugin for Windows (replaces pwsh and WSL-only bash) |
 | [dsh-custom-skin](https://github.com/SLin-code/dsh-custom-skin) | 20 | ⚪ unknown | DSH自定义壁纸/皮肤插件——Custom wallpapers and translucent skins for DeepSeek Harness Web |
+| [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) | 0 | ⚪ unknown | Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock. |
 
 ### 🐋 Skins
 
@@ -1901,7 +1902,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-dingtalk](https://github.com/DingTalk-Real-AI/dsh-dingtalk) | 12 | ⚪ unknown | Official DingTalk connector for DeepSeek Harness |
 
 > Badges: 🟢 compatible · 🔴 broken · ⚪ unverified · ⚫ unmaintained.
-> 1764 entries total, grouped by category, sorted by ⭐ within each. Schema dictionary: [docs/catalog-schema.md](docs/catalog-schema.md).
+> 1765 entries total, grouped by category, sorted by ⭐ within each. Schema dictionary: [docs/catalog-schema.md](docs/catalog-schema.md).
 <!-- CATALOG:END -->
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-suite
 
 ![GitHub stars](https://img.shields.io/github/stars/whyihaveyou/dsh-suite?style=flat-square&color=facc15)
-![Plugins](https://img.shields.io/badge/plugins-1764-facc15?style=flat-square)
+![Plugins](https://img.shields.io/badge/plugins-1765-facc15?style=flat-square)
 ![Daily compat](https://img.shields.io/github/actions/workflow/status/whyihaveyou/dsh-suite/compat.yml?branch=main&label=daily-compat-check&style=flat-square)
 ![License](https://img.shields.io/badge/license-MIT-3b82f6?style=flat-square)
 
@@ -932,6 +932,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-custom-background](https://github.com/StarryHui/dsh-custom-background) | 8 | ⚪ unknown | untranslated |
 | [dsh-win-gitbash](https://github.com/buhuikongpan/dsh-win-gitbash) | 8 | ⚪ unknown | untranslated |
 | [dsh-custom-skin](https://github.com/SLin-code/dsh-custom-skin) | 20 | ⚪ unknown | untranslated |
+| [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) | 0 | ⚪ unknown | 为 DSH Web 提供持久的 tmux 控制模式驾驶舱，在停靠栏中镜像原生窗格。 |
 
 ### 🐋 皮肤
 
@@ -1901,7 +1902,7 @@ npm create dsh-plugin@latest my-plugin
 | [dsh-dingtalk](https://github.com/DingTalk-Real-AI/dsh-dingtalk) | 12 | ⚪ unknown | untranslated |
 
 > 徽章含义：🟢 兼容 · 🔴 不兼容 · ⚪ 未实测 · ⚫ 弃坑。
-> 共 1764 个条目，按分类分表、类内按 ⭐ 降序。收录 / 字段词典见 [docs/catalog-schema.md](docs/catalog-schema.md)。
+> 共 1765 个条目，按分类分表、类内按 ⭐ 降序。收录 / 字段词典见 [docs/catalog-schema.md](docs/catalog-schema.md)。
 <!-- CATALOG:END -->
 
 ## 兼容性

--- a/data/plugins.json
+++ b/data/plugins.json
@@ -65295,8 +65295,57 @@
    "isOfficialBeta": false,
    "language": "JavaScript",
    "sourceNote": "auto"
-  }
- ],
+  },
+    {
+      "id": "dsh-tmux-cc",
+      "name": "dsh-tmux-cc",
+      "npm": "",
+      "repo": "adrianleb/dsh-tmux-cc",
+      "url": "https://github.com/adrianleb/dsh-tmux-cc",
+      "category": "ui",
+      "description": {
+        "en": "Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock.",
+        "zh": "为 DSH Web 提供持久的 tmux 控制模式驾驶舱，在停靠栏中镜像原生窗格。"
+      },
+      "author": "adrianleb",
+      "stars": 0,
+      "license": "MIT",
+      "tags": [
+        "tmux",
+        "terminal",
+        "ui"
+      ],
+      "dsh": {
+        "minVersion": "",
+        "peerCordis": "^4.0.1",
+        "node": ">=22.6"
+      },
+      "compat": {
+        "status": "unknown",
+        "dshVersion": "",
+        "lastVerified": "",
+        "note": ""
+      },
+      "install": "dsh plugin --profile web add github:adrianleb/dsh-tmux-cc",
+      "featured": false,
+      "isOfficialBeta": false,
+      "language": "TypeScript",
+      "sourceNote": "",
+      "last_push": "2026-08-26",
+      "evidence": {
+        "level": 1,
+        "l3Verified": false,
+        "source": "author submission"
+      },
+      "risk": {
+        "installScript": false,
+        "networkEgress": null,
+        "shellAccess": true,
+        "noLicense": false
+      },
+      "installNote": "Requires tmux on the DSH host. Access to the DSH Web port is shell-equivalent for that user's tmux sessions."
+    }
+],
  "watchlist": [
   {
    "id": "openbiliclaw",


### PR DESCRIPTION
Author submission for [adrianleb/dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc).

- category: `ui`
- `compat.status`: `unknown` (left for maintainer install CI)
- install: `dsh plugin --profile web add github:adrianleb/dsh-tmux-cc`
- license: MIT
- bilingual descriptions
- regenerated README tables via `npm run gen:readme`

Also opening the inclusion-request issue as requested in CONTRIBUTING.