### PR TITLE
feat(create-dsh-plugin): add opt-in community naming declarations

### DIFF
--- a/packages/create-dsh-plugin/README.md
+++ b/packages/create-dsh-plugin/README.md
@@ -17,6 +17,7 @@ npx create-dsh-plugin [project-dir] [options]
 
 # Non-interactive / 非交互
 npx create-dsh-plugin my-plugin -t tool
+npx create-dsh-plugin my-plugin -t tool --registry-owner your-github-owner
 npx create-dsh-plugin my-events -t events --yes --verify
 npx create-dsh-plugin my-webui -t webui -n my-webui --tool-name my_note --verify
 
@@ -32,6 +33,8 @@ npx create-dsh-plugin
 | `-n, --name <pkg>` | npm package name (derived from dir by default) |
 | `--plugin-id <id>` | cordis patch row id + plugin `name` export (derived from package name) |
 | `--tool-name <name>` | Tool name for `tool`/`webui` (derived from package name) |
+| `--registry-owner <github-owner>` | Generate an optional community `dsh-plugin.naming.json` declaration |
+| `--registry-name <slug>` | Override the coordinate slug derived from the package name |
 | `-y, --yes` | Skip prompts, use defaults |
 | `--verify` | After generation, build + install into a temp profile + dump-config |
 | `--skip-install` | Skip `pnpm install` inside the generated project |
@@ -54,6 +57,33 @@ Every generated project ships, out of the box:
 - `tsconfig.json` (pure ESM, `module: esnext` + `moduleResolution: bundler`).
 - `dsh.bundle` manifest + `cordis.patch.yml` (bundle distribution).
 - a `README.md` with the **10 pitfalls** (from a real, verified spike) + 防呆注释 in the code.
+
+## Community naming declaration / 社区命名清单
+
+Pass `--registry-owner <github-owner>` when the public repository owner is known. The scaffold then
+generates `dsh-plugin.naming.json` with the plugin coordinate, package, Loader ID, tool names, consumed
+event channels, and HTTP routes that are deterministically known from the selected template.
+When the caller does not override `--plugin-id` or `--tool-name`, this opt-in mode also derives
+collision-resistant defaults such as `owner-plugin` and `owner_plugin`.
+
+公开仓库 owner 已确定时，可传入 `--registry-owner <github-owner>`。脚手架会生成
+`dsh-plugin.naming.json`，记录能够从模板参数确定的插件 coordinate、package、Loader ID、
+tool、消费的 event channel 和 HTTP route。
+如果没有显式覆盖 `--plugin-id` 或 `--tool-name`，该模式还会生成 `owner-plugin` 和
+`owner_plugin` 形式的低碰撞默认名。
+
+This is an opt-in community coordination declaration, not an official Harness manifest and not an ID
+reservation. Validate it locally with the
+[`plugin-write` naming workflow](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/tree/main/skills/plugin-write),
+then optionally query reviewed registrations in
+[`dsh-plugin-registry`](https://github.com/zp-home/dsh-plugin-registry). No registry write occurs during
+scaffolding, and omitting the flag preserves the existing generated project exactly.
+
+这是可选的社区协调声明，不是 Harness 官方 manifest，也不会预留 ID。先使用
+[`plugin-write` 命名流程](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/tree/main/skills/plugin-write)
+做本地校验，再按需查询
+[`dsh-plugin-registry`](https://github.com/zp-home/dsh-plugin-registry) 中经过审核的登记。
+脚手架不会写入中央仓库；不传该参数时，生成结果与原行为一致。
 
 ## Why the version pinning matters / 为什么锁 next 版本
 

--- a/packages/create-dsh-plugin/src/args.js
+++ b/packages/create-dsh-plugin/src/args.js
@@ -9,6 +9,8 @@ export function parseArgs(argv) {
     name: { type: 'string', short: 'n' },
     'plugin-id': { type: 'string' },
     'tool-name': { type: 'string' },
+    'registry-owner': { type: 'string' },
+    'registry-name': { type: 'string' },
     yes: { type: 'boolean', short: 'y' },
     verify: { type: 'boolean' },
     'skip-install': { type: 'boolean' },
@@ -35,6 +37,8 @@ ${paint(c.cyan, 'Options / 选项')}
   -n, --name <pkg>           npm package name (默认由目录名推导)
       --plugin-id <id>       cordis patch row id + plugin name export (默认由包名推导)
       --tool-name <name>     Tool name for tool/webui templates (默认由包名推导)
+      --registry-owner <id>  GitHub owner for optional community naming declaration
+      --registry-name <id>   Coordinate slug (derived from package name by default)
   -y, --yes                  Skip prompts, use defaults (跳过向导用默认值)
       --verify               After generation: build + install into a temp profile + dump-config (生成后自动验证装载)
       --skip-install         Do not run package install inside the generated project
@@ -43,6 +47,7 @@ ${paint(c.cyan, 'Options / 选项')}
 
 ${paint(c.cyan, 'Examples / 示例')}
   npx create-dsh-plugin my-plugin -t tool
+  npx create-dsh-plugin my-plugin -t tool --registry-owner your-github-owner
   npx create-dsh-plugin my-events -t events --yes --verify
   npx create-dsh-plugin                            # interactive wizard / 交互向导
 `

--- a/packages/create-dsh-plugin/src/cli.js
+++ b/packages/create-dsh-plugin/src/cli.js
@@ -9,6 +9,7 @@ import { TEMPLATES, TEMPLATE_META } from './templates.js'
 import { runWizard, pkgNameFromDir, pluginIdFromPkg, toolNameFromPkg } from './prompt.js'
 import { generate } from './generate.js'
 import { verify } from './verify.js'
+import { registryIdentityFromPackage } from './naming.js'
 
 function version() {
   try {
@@ -29,6 +30,8 @@ async function main() {
     template: flags.template,
     pluginId: flags['plugin-id'],
     toolName: flags['tool-name'],
+    registryOwner: flags['registry-owner'],
+    registryName: flags['registry-name'],
     verify: flags.verify === true ? true : undefined,
     skipInstall: flags['skip-install'] === true,
   }
@@ -49,14 +52,24 @@ async function main() {
     process.exit(1)
   }
 
-  // Fill remaining fields with safe defaults (bilingual note).
-  cfg.name = cfg.name || pkgNameFromDir(cfg.targetDir)
-  cfg.pluginId = cfg.pluginId || pluginIdFromPkg(cfg.name)
-  const meta = TEMPLATE_META[cfg.template]
-  if (meta.asksToolName) cfg.toolName = cfg.toolName || toolNameFromPkg(cfg.name)
-  cfg.verify = cfg.verify === true
-
   try {
+    // Fill remaining fields with safe defaults (bilingual note).
+    cfg.name = cfg.name || pkgNameFromDir(cfg.targetDir)
+    if (cfg.registryName && !cfg.registryOwner) {
+      throw new Error('--registry-name requires --registry-owner')
+    }
+    const meta = TEMPLATE_META[cfg.template]
+    const registryIdentity = cfg.registryOwner
+      ? registryIdentityFromPackage(cfg.name, cfg.registryOwner, cfg.registryName)
+      : null
+    if (registryIdentity) {
+      cfg.registryOwner = registryIdentity.namespace
+      cfg.registryName = registryIdentity.name
+    }
+    cfg.pluginId = cfg.pluginId || registryIdentity?.loaderId || pluginIdFromPkg(cfg.name)
+    if (meta.asksToolName) cfg.toolName = cfg.toolName || registryIdentity?.toolName || toolNameFromPkg(cfg.name)
+    cfg.verify = cfg.verify === true
+
     const result = await generate(cfg)
 
     if (cfg.verify) {
@@ -71,6 +84,9 @@ async function main() {
     console.log(paint(c.dim, '  # from the PARENT directory, install into a profile:'))
     console.log(paint(c.dim, `  dsh plugin --profile my-profile add ${addSpec}`))
     console.log(paint(c.dim, '  dsh --profile my-profile            # boot and watch the plugin load'))
+    if (cfg.registryOwner) {
+      console.log(paint(c.dim, '  # dsh-plugin.naming.json is a community declaration, not an ID reservation'))
+    }
     console.log('')
   } catch (e) {
     console.error(err(`✘ ${e?.message || String(e)}`))

--- a/packages/create-dsh-plugin/src/generate.js
+++ b/packages/create-dsh-plugin/src/generate.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join, relative, resolve } from 'node:path'
 import { c, paint, ok, exists, writeFileDeep, readText, resolveDshVersions } from './util.js'
 import { TEMPLATE_META, PITFALLS } from './templates.js'
+import { createNamingManifest } from './naming.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const TEMPLATES_ROOT = resolve(here, '../templates')
@@ -73,11 +74,21 @@ export async function generate(cfg) {
     written.push(rel)
   }
 
+  const namingManifest = createNamingManifest(cfg)
+  if (namingManifest) {
+    const namingFile = 'dsh-plugin.naming.json'
+    await writeFileDeep(join(targetAbs, namingFile), `${JSON.stringify(namingManifest, null, 2)}\n`)
+    written.push(namingFile)
+  }
+
   console.log('')
   console.log(ok(`✔ Generated ${cfg.template} plugin in ${targetAbs} (生成完成)`))
   console.log(paint(c.dim, `  template: ${cfg.template}  package: ${cfg.name}  plugin-id: ${cfg.pluginId}`))
   console.log(paint(c.dim, `  @deepseek-ai/dsh-tools pinned to ${versions.dshTools} (next tag; latest is stale 0.0.1-rc.1)`))
   console.log(paint(c.dim, `  files: ${written.join(', ')}`))
+  if (namingManifest) {
+    console.log(paint(c.dim, `  community coordinate: ${namingManifest.plugin.coordinate} (not a reservation)`))
+  }
 
   return { cfg, versions, files: written, targetAbs }
 }

--- a/packages/create-dsh-plugin/src/naming.js
+++ b/packages/create-dsh-plugin/src/naming.js
@@ -1,0 +1,85 @@
+// Optional community naming declaration for reviewed cross-repository checks.
+// This is separate from the official package.json/dsh.bundle contract.
+
+const namespacePattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/
+const pluginNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/
+const nonWhitespacePattern = /^\S+$/
+const toolNamePattern = /^[A-Za-z0-9_-]+$/
+
+export function registryIdentityFromPackage(packageName, owner, requestedName) {
+  const normalizedPackageName = String(packageName).trim()
+  if (!packageNamePattern.test(normalizedPackageName) || normalizedPackageName.length > 214) {
+    throw new Error('--name must be a valid lowercase npm package name when --registry-owner is supplied')
+  }
+  const namespace = String(owner).trim().toLowerCase()
+  if (!namespacePattern.test(namespace) || namespace.length > 63) {
+    throw new Error('--registry-owner must be a lowercase GitHub owner such as alice or alice-labs')
+  }
+  const packageSlug = normalizedPackageName.split('/').pop()
+  const derivedName = packageSlug.replace(/^dsh-(?:plugin-)?/, '') || packageSlug
+  const name = String(requestedName || derivedName).trim().toLowerCase()
+  if (!pluginNamePattern.test(name) || name.length > 63) {
+    throw new Error('--registry-name must use lowercase kebab-case')
+  }
+  return {
+    namespace,
+    name,
+    coordinate: `${namespace}/${name}`,
+    loaderId: `${namespace}-${name}`,
+    toolName: `${namespace}-${name}`.replaceAll('-', '_'),
+  }
+}
+
+function routesFor(template, pluginId) {
+  if (template === 'panel') {
+    return [{ kind: 'exact', path: `/${pluginId}/ping` }]
+  }
+  if (template === 'preset-pack') {
+    return ['list', 'apply', 'remove'].map((operation) => ({
+      kind: 'exact',
+      path: `/${pluginId}/${operation}`,
+    }))
+  }
+  return []
+}
+
+function eventsFor(template) {
+  if (template !== 'events') return []
+  return ['session/event', 'tools/change', 'tools/pre-execute']
+}
+
+export function createNamingManifest(cfg) {
+  if (!cfg.registryOwner) return null
+
+  const identity = registryIdentityFromPackage(cfg.name, cfg.registryOwner, cfg.registryName)
+  if (!nonWhitespacePattern.test(cfg.pluginId)) {
+    throw new Error('--plugin-id must be a non-whitespace name when --registry-owner is supplied')
+  }
+  if (cfg.toolName && !toolNamePattern.test(cfg.toolName)) {
+    throw new Error('--tool-name contains characters unsupported by the community naming declaration')
+  }
+
+  return {
+    schemaVersion: 1,
+    policy: 'dsh-plugin-naming/v1',
+    plugin: {
+      namespace: identity.namespace,
+      name: identity.name,
+      coordinate: identity.coordinate,
+      packageName: cfg.name,
+    },
+    names: {
+      pluginNames: [cfg.pluginId],
+      loaderIds: [cfg.pluginId],
+      services: [],
+      tools: ['tool', 'webui'].includes(cfg.template) && cfg.toolName ? [cfg.toolName] : [],
+      commands: [],
+      skills: [],
+      skillProviders: [],
+      events: eventsFor(cfg.template),
+      settingsNamespaces: [],
+      routes: routesFor(cfg.template, cfg.pluginId),
+    },
+  }
+}

--- a/packages/create-dsh-plugin/src/prompt.js
+++ b/packages/create-dsh-plugin/src/prompt.js
@@ -3,6 +3,7 @@ import { createInterface } from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { c, paint } from './util.js'
 import { TEMPLATES, TEMPLATE_META } from './templates.js'
+import { registryIdentityFromPackage } from './naming.js'
 
 // Derive a valid npm package name from a directory name.
 export function pkgNameFromDir(dir) {
@@ -64,13 +65,28 @@ export async function runWizard(initial) {
     if (result.template && !TEMPLATES.includes(result.template)) result.template = 'tool'
 
     const meta = TEMPLATE_META[result.template]
+    if (!result.registryOwner) {
+      const owner = await ask(`${paint(c.bold, 'GitHub owner（可选，生成社区命名清单） optional registry owner')}: `)
+      result.registryOwner = owner || undefined
+    }
+    let registryIdentity = null
+    if (result.registryOwner) {
+      const derived = registryIdentityFromPackage(result.name, result.registryOwner, result.registryName)
+      if (!result.registryName) {
+        const registryName = await ask(`${paint(c.bold, '注册名 registry name')} (${derived.name}): `)
+        result.registryName = registryName || derived.name
+      }
+      registryIdentity = registryIdentityFromPackage(result.name, result.registryOwner, result.registryName)
+      result.registryOwner = registryIdentity.namespace
+      result.registryName = registryIdentity.name
+    }
     if (!result.pluginId) {
-      const autoId = pluginIdFromPkg(result.name)
+      const autoId = registryIdentity?.loaderId || pluginIdFromPkg(result.name)
       const id = await ask(`${paint(c.bold, '插件 id plugin id')} (${autoId}): `)
       result.pluginId = id || autoId
     }
     if (meta.asksToolName && !result.toolName) {
-      const autoTool = toolNameFromPkg(result.name)
+      const autoTool = registryIdentity?.toolName || toolNameFromPkg(result.name)
       const tn = await ask(`${paint(c.bold, '工具名 tool name')} (${autoTool}): `)
       result.toolName = tn || autoTool
     }

--- a/packages/create-dsh-plugin/test/smoke.test.mjs
+++ b/packages/create-dsh-plugin/test/smoke.test.mjs
@@ -6,8 +6,9 @@ import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
+import { createNamingManifest, registryIdentityFromPackage } from '../src/naming.js'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const CLI = join(here, '..', 'src', 'cli.js')
@@ -39,13 +40,65 @@ test('--help renders bilingual usage', () => {
   assert.equal(r.status, 0)
   assert.match(r.stdout, /Usage/)
   assert.match(r.stdout, /用法/)
+  assert.match(r.stdout, /--registry-owner/)
+})
+
+test('builds deterministic community naming claims for every template surface', () => {
+  assert.deepEqual(registryIdentityFromPackage('@alice-labs/dsh-clock', 'alice-labs'), {
+    namespace: 'alice-labs',
+    name: 'clock',
+    coordinate: 'alice-labs/clock',
+    loaderId: 'alice-labs-clock',
+    toolName: 'alice_labs_clock',
+  })
+  const base = {
+    registryOwner: 'alice-labs',
+    registryName: 'clock',
+    name: '@alice-labs/dsh-clock',
+    pluginId: 'dsh-clock',
+  }
+  const tool = createNamingManifest({ ...base, template: 'tool', toolName: 'alice_clock_now' })
+  assert.equal(tool.plugin.coordinate, 'alice-labs/clock')
+  assert.deepEqual(tool.names.loaderIds, ['dsh-clock'])
+  assert.deepEqual(tool.names.tools, ['alice_clock_now'])
+
+  const events = createNamingManifest({ ...base, template: 'events' })
+  assert.deepEqual(events.names.events, ['session/event', 'tools/change', 'tools/pre-execute'])
+
+  const panel = createNamingManifest({ ...base, template: 'panel' })
+  assert.deepEqual(panel.names.routes, [{ kind: 'exact', path: '/dsh-clock/ping' }])
+
+  const presets = createNamingManifest({ ...base, template: 'preset-pack' })
+  assert.deepEqual(presets.names.routes.map((route) => route.path), [
+    '/dsh-clock/list',
+    '/dsh-clock/apply',
+    '/dsh-clock/remove',
+  ])
+  assert.throws(
+    () => createNamingManifest({ ...base, registryOwner: 'Not Valid', template: 'tool' }),
+    /--registry-owner/,
+  )
+})
+
+test('requires an owner when a registry name is supplied', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'dsh-scaffold-'))
+  try {
+    const r = runCli([dir, '-t', 'tool', '--registry-name', 'clock', '--yes'])
+    assert.notEqual(r.status, 0)
+    assert.match(r.stdout + r.stderr, /--registry-name requires --registry-owner/)
+    assert.doesNotMatch(r.stdout + r.stderr, /\n\s+at /, 'expected a concise CLI error without a stack trace')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })
 
 test('generates the tool template with a non-stale dsh-tools pin', () => {
-  const dir = generate('tool', 'verify-tool', ['--plugin-id', 'verify-tool', '--tool-name', 'verify_time'])
+  const dir = generate('tool', 'verify-tool', [
+    '--registry-owner', 'alice',
+  ])
   try {
     // No leftover {{token}} anywhere.
-    for (const f of ['package.json', 'cordis.patch.yml', 'src/index.ts', 'README.md', 'tsconfig.json']) {
+    for (const f of ['package.json', 'cordis.patch.yml', 'dsh-plugin.naming.json', 'src/index.ts', 'README.md', 'tsconfig.json']) {
       assert.ok(!read(dir, f).includes('{{'), `${f} has a leftover {{token}}`)
     }
     const pkg = JSON.parse(read(dir, 'package.json'))
@@ -55,9 +108,15 @@ test('generates the tool template with a non-stale dsh-tools pin', () => {
     assert.notEqual(dep, '0.0.1-rc.1', 'STALE dsh-tools version (npm latest tag) leaked through')
     assert.match(dep, /^\d+\.\d+\.\d+/, 'dsh-tools should be pinned exactly')
     assert.match(read(dir, 'cordis.patch.yml'), /- insert:/)
+    assert.match(read(dir, 'cordis.patch.yml'), /id: alice-verify-tool/, 'registry opt-in should use a collision-aware Loader ID')
     assert.match(read(dir, 'cordis.patch.yml'), /name: verify-tool/, 'patch name must be the package name')
     assert.match(read(dir, 'src/index.ts'), /defineTool/)
-    assert.match(read(dir, 'src/index.ts'), /export const name = 'verify-tool'/)
+    assert.match(read(dir, 'src/index.ts'), /export const name = 'alice-verify-tool'/)
+    const naming = JSON.parse(read(dir, 'dsh-plugin.naming.json'))
+    assert.equal(naming.policy, 'dsh-plugin-naming/v1')
+    assert.equal(naming.plugin.coordinate, 'alice/verify-tool')
+    assert.deepEqual(naming.names.loaderIds, ['alice-verify-tool'])
+    assert.deepEqual(naming.names.tools, ['alice_verify_tool'])
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -66,6 +125,7 @@ test('generates the tool template with a non-stale dsh-tools pin', () => {
 test('generates the events template with zero runtime dependencies', () => {
   const dir = generate('events', 'verify-events', ['--plugin-id', 'verify-events'])
   try {
+    assert.equal(existsSync(join(dir, 'dsh-plugin.naming.json')), false, 'registry opt-out must not add a declaration')
     const pkg = JSON.parse(read(dir, 'package.json'))
     assert.deepEqual(pkg.dependencies ?? {}, {}, 'events template must have NO runtime deps')
     const dev = pkg.devDependencies['@deepseek-ai/dsh-tools']
@@ -73,6 +133,23 @@ test('generates the events template with zero runtime dependencies', () => {
     assert.notEqual(dev, '0.0.1-rc.1', 'STALE dsh-tools version leaked through')
     assert.match(read(dir, 'src/index.ts'), /ctx\.on\(/)
     assert.match(read(dir, 'src/index.ts'), /ctx\.effect\(/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('registry opt-in preserves explicit plugin and tool names', () => {
+  const dir = generate('tool', 'verify-explicit', [
+    '--registry-owner', 'alice',
+    '--plugin-id', 'ExistingPluginName',
+    '--tool-name', 'existing_tool',
+  ])
+  try {
+    const naming = JSON.parse(read(dir, 'dsh-plugin.naming.json'))
+    assert.deepEqual(naming.names.pluginNames, ['ExistingPluginName'])
+    assert.deepEqual(naming.names.loaderIds, ['ExistingPluginName'])
+    assert.deepEqual(naming.names.tools, ['existing_tool'])
+    assert.match(read(dir, 'src/index.ts'), /export const name = 'ExistingPluginName'/)
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/scripts/verify-repo.mjs
+++ b/scripts/verify-repo.mjs
@@ -3,7 +3,7 @@
  * verify-repo.mjs — repo-level CI quality gate (push / PR).
  *
  * Five checks, all zero-dependency (Node built-ins only):
- *   1. test    — packages/create-dsh-plugin smoke tests (`pnpm test`, 7 cases)
+ *   1. test    — packages/create-dsh-plugin smoke tests (`pnpm test`)
  *   2. build   — packages/plugins/* `tsc` build (every plugin with real sources)
  *   3. readme  — gen-readme idempotency: re-run and assert `git diff --exit-code`
  *   4. data    — data/plugins.json structural validation (id uniqueness, enum


### PR DESCRIPTION
# 中文

## 摘要

本 PR 为 `create-dsh-plugin` 增加可选的社区命名清单生成能力。插件作者明确传入 `--registry-owner` 后，脚手架会生成 `dsh-plugin.naming.json`，并为未显式指定的 Loader ID 与工具名提供带发布者前缀的低碰撞默认值。

默认脚手架行为保持不变：不传该参数时不会新增清单、不会改变现有默认名称，也不会访问或写入任何中央注册表。

## 为什么要做

DeepSeek Harness 没有一个可以覆盖所有冲突面的“通用插件 ID”。npm 包名、插件模块名、Loader 行 ID、工具名、事件通道和 Web 路由分别由不同运行时边界管理，重复名称造成的后果也不同。仅靠一个简短插件名无法说明插件实际占用了哪些名称。

中央冲突查询还需要稳定、可审查的本地输入。如果每个开发者手写清单，字段容易遗漏，也容易与模板真正生成的代码脱节。脚手架已经掌握包名、模板、插件 ID、工具名、事件订阅和路由，因此它是生成第一手命名声明的合适位置。

## 设计与实现

- 新增 `--registry-owner <github-owner>`，显式启用社区命名清单。
- 新增 `--registry-name <slug>`，允许覆盖从 npm 包名推导的坐标名称；该参数必须和 owner 一起使用。
- 生成 `<owner>/<plugin>` 社区坐标，以及 `owner-plugin` Loader ID 和 `owner_plugin` 工具名默认值。
- 生成 `dsh-plugin.naming.json`，覆盖插件模块名、Loader ID、工具名、消费的事件通道和模板实际注册的 exact 路由；未占用的名称面保留为空数组。
- `events` 模板只声明其实际消费的 `session/event`、`tools/change` 和 `tools/pre-execute`。
- `panel` 与 `preset-pack` 只声明模板代码实际注册的路由，不猜测未生成的能力。
- 调用者显式传入的 `--plugin-id` 和 `--tool-name` 保持不变，不以社区建议强制重命名已有公开名称。
- 清单生成是纯本地、零依赖操作；不执行网络查询、不自动提交登记，也不声称预留任何 ID。

## 能带来的效果

新插件可以在创建时就获得机器可读、可复现的名称占用清单，减少后续人工盘点遗漏。带 owner 的默认 Loader ID 和工具名也能在开发阶段主动降低跨发布者重名概率。

这份清单可以直接交给 `dsh-plugin-upgrade-skill` 的本地校验器，并可选地查询经过审核的 v2 中央索引。这样，静态规范提示和跨仓冲突查询使用同一份输入，同时仍由代码评审决定是否正式登记。

## 关联工作

- 本地命名规范、校验器和只读查询流程：<https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/pull/36>
- 上下文感知的 v2 注册表和发现流程：<https://github.com/zp-home/dsh-plugin-registry/pull/2>

本 PR 不复制这两个仓库的校验或注册逻辑，只负责从脚手架的确定性输入生成声明。因此它不会给 `create-dsh-plugin` 增加远程服务依赖。

## 验证

已通过：

- `npm test`：9 项通过，1 项按仓库设计跳过；覆盖 opt-in、opt-out、显式名称保留、无 owner 的错误提示，以及所有模板名称面映射。
- `node --check`：所有修改的 JavaScript 文件语法检查通过。
- `npm pack --dry-run --json`：确认新增的 `src/naming.js` 会进入发布包。
- `node scripts/verify-repo.mjs --only data`：通过。
- `node scripts/verify-repo.mjs --only leak`：通过，未发现凭据或绝对路径泄漏。
- `node scripts/verify-repo.mjs --only readme`：通过，生成的目录 README 无漂移。
- `git diff --check`：通过。

真实跨仓样例：

```text
package: @alice/dsh-clock
coordinate: alice/clock
Loader ID: alice-clock
tool: alice_clock
```

该样例通过 `validate-names.mjs --strict`，结果为 0 个错误和 0 个警告；随后通过本地 `dsh-plugin-registry/v2` 索引查询，结果为 0 个错误、0 个警告、0 个通知。查询结果同时明确提示：没有匹配并不等于全局唯一性证明。

环境受限：

- `node scripts/verify-repo.mjs --only test` 在本机 Windows 环境中无法由 Node 子进程启动 `pnpm` shim；等价的包级 `npm test` 已完整通过。
- `node scripts/compat-check.mjs` 能运行到完成，但同一子进程限制使 npm 查询全部标记为 unavailable；生成报告已撤回，未作为成功证据提交。
- 需要 pnpm、网络和临时 Harness profile 的真实 `--verify` 测试保持跳过，交由仓库 CI 和维护者环境验证。

## 限制与安全边界

- `dsh-plugin.naming.json` 是社区兼容性声明，不是 DeepSeek Harness 官方 manifest。
- 清单不会预留名称，也不会自动写中央仓库；正式登记仍需来源证明和人工评审。
- 事件是共享通道，不应把同名消费视为独占冲突；Loader、工具和路由冲突还需要结合层、scope、Harness 版本和路由 kind 判断。
- 端口属于部署配置，不进入全局命名登记。
- `events` 模板消费的是 Harness 内置事件，panel 类模板保留现有实际路由；严格社区建议可能提示前缀优化，但本 PR 不为消除建议而改写既有模板协议。
- v2 中央查询目前依赖上面的关联 PR；脚手架运行时不依赖它们是否在线或已经合并。

## 发布说明

`create-dsh-plugin` 现在可以选择生成社区命名清单和带发布者前缀的默认名称，帮助插件作者在开发阶段更早发现潜在冲突；未启用时行为完全不变。

---

# English

## Summary

This PR adds opt-in community naming declaration generation to `create-dsh-plugin`. When an author explicitly supplies `--registry-owner`, the scaffold writes `dsh-plugin.naming.json` and uses publisher-prefixed, collision-resistant defaults for Loader IDs and tool names that were not explicitly provided.

The default scaffold behavior is unchanged. Without the flag, no declaration is added, existing naming defaults are preserved, and no central registry is read or written.

## Why This Is Needed

DeepSeek Harness does not have one universal plugin ID covering every collision surface. npm package names, plugin module names, Loader row IDs, tool names, event channels, and Web routes are owned by different runtime boundaries and have different duplicate semantics. A single short plugin name cannot describe what a plugin actually occupies.

Central conflict checks also need stable, reviewable local input. Hand-written declarations are easy to omit or let drift from generated code. The scaffold already knows the package, template, plugin ID, tool name, event subscriptions, and routes, so it is the appropriate place to generate the source declaration.

## Design And Implementation

- Add `--registry-owner <github-owner>` to explicitly enable a community naming declaration.
- Add `--registry-name <slug>` to override the coordinate name derived from the npm package; it requires an owner.
- Derive an `<owner>/<plugin>` community coordinate plus `owner-plugin` Loader and `owner_plugin` tool defaults.
- Generate `dsh-plugin.naming.json` covering plugin module names, Loader IDs, tools, consumed event channels, and exact routes actually registered by the selected template; unoccupied surfaces remain empty arrays.
- The `events` template declares only the three channels it consumes: `session/event`, `tools/change`, and `tools/pre-execute`.
- The `panel` and `preset-pack` templates declare only routes present in their generated source.
- Explicit `--plugin-id` and `--tool-name` values are preserved instead of forcibly renaming existing public names to satisfy community recommendations.
- Declaration generation is local and dependency-free. It performs no network query, automatic registration, or ID reservation.

## Effect

New plugins can start with a machine-readable, reproducible inventory of occupied names instead of relying on a later manual audit. Publisher-prefixed Loader and tool defaults also reduce the probability of cross-publisher collisions at development time.

The declaration can be passed directly to the local validator in `dsh-plugin-upgrade-skill` and optionally checked against the reviewed v2 central index. Static guidance and cross-repository checks therefore share one input while formal registration remains review-controlled.

## Related Work

- Local naming policy, validator, and read-only query workflow: <https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/pull/36>
- Context-aware v2 registry and discovery workflow: <https://github.com/zp-home/dsh-plugin-registry/pull/2>

This PR does not duplicate validation or registration logic from those repositories. It only generates a declaration from deterministic scaffold input, so `create-dsh-plugin` gains no remote service dependency.

## Verification

Passed:

- `npm test`: 9 passed and 1 repository-defined test skipped, covering opt-in, opt-out, explicit-name preservation, the missing-owner error, and all template surface mappings.
- `node --check`: all modified JavaScript files passed syntax checks.
- `npm pack --dry-run --json`: confirmed that the published package includes `src/naming.js`.
- `node scripts/verify-repo.mjs --only data`: passed.
- `node scripts/verify-repo.mjs --only leak`: passed with no credential or absolute-path leaks.
- `node scripts/verify-repo.mjs --only readme`: passed with no generated catalog README drift.
- `git diff --check`: passed.

Real cross-repository example:

```text
package: @alice/dsh-clock
coordinate: alice/clock
Loader ID: alice-clock
tool: alice_clock
```

The example passed `validate-names.mjs --strict` with zero errors and zero warnings. A subsequent query against the local `dsh-plugin-registry/v2` index returned zero errors, zero warnings, and zero notices, while explicitly retaining the warning that no match is not proof of global uniqueness.

Environment-limited:

- `node scripts/verify-repo.mjs --only test` could not launch the `pnpm` shim from a Node child process in this Windows environment; the equivalent package-level `npm test` completed successfully.
- `node scripts/compat-check.mjs` ran to completion, but the same child-process limitation marked every npm lookup unavailable. The generated report was reverted and is not presented as passing evidence.
- The real `--verify` path requiring pnpm, network access, and a temporary Harness profile remains skipped for repository CI or a maintainer environment.

## Limits And Safety Boundaries

- `dsh-plugin.naming.json` is a community compatibility declaration, not an official DeepSeek Harness manifest.
- A declaration does not reserve names or write to the central repository. Formal registration still requires source proof and human review.
- Events are shared channels and same-name consumption is not exclusive. Loader, tool, and route matches still require layer, scope, Harness version, and route-kind context.
- Ports are deployment configuration and are intentionally excluded from global naming registration.
- The events template consumes built-in Harness channels, and panel templates keep their actual existing routes. Strict community recommendations may suggest stronger prefixes, but this PR does not rewrite established template protocols merely to remove recommendations.
- The optional v2 central check currently depends on the related PRs above; scaffold runtime behavior does not depend on their availability or merge state.

## Release Notes

`create-dsh-plugin` can now optionally generate a community naming declaration and publisher-prefixed defaults so plugin authors can detect potential conflicts earlier, with no behavior change unless the feature is enabled.
