### PR TITLE
Add dsplugin.app to README Ecosystem links

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,7 @@
 
 **🧭 Ecosystem / 生态**
 
+- 🗂️ [dsplugin.app](https://dsplugin.app/) — Unofficial community DeepSeek Harness plugin directory / registry; review source and Manifest/`dsh.bundle` before install
 - 🌐 [Directory](https://whyihaveyou.github.io/dsh-suite/) — browse every plugin online
 - 📖 [DSH Chinese docs · dsh-docs.com](https://dsh-docs.com) — Chinese tutorials & docs, no VPN needed
 - 📕 [DSH plugin dev guide](https://github.com/whyihaveyou/dsh-plugin-tutorial) — the bilingual book

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 **🧭 生态 / Ecosystem**
 
+- 🗂️ [dsplugin.app](https://dsplugin.app/) — 非官方社区 DeepSeek Harness 插件目录 / 注册表；安装前请查看来源与 Manifest/`dsh.bundle`
 - 🌐 [目录网站](https://whyihaveyou.github.io/dsh-suite/zh.html) — 在线逛全部插件
 - 📖 [DSH 中文文档 · dsh-docs.com](https://dsh-docs.com) — 中文教程与文档，开箱即用无需翻墙
 - 📕 [DSH 插件开发指南](https://github.com/whyihaveyou/dsh-plugin-tutorial) — 中英双语成书


### PR DESCRIPTION
## Summary
- Add [dsplugin.app](https://dsplugin.app/) to the **🧭 Ecosystem** bullet list in README.md and README.en.md.
- Unofficial community DeepSeek Harness plugin directory / registry; review source and Manifest/`dsh.bundle` before install.
- README / ecosystem section only — not added as a plugin table / form / catalog CSV row.

## Test plan
- [ ] Ecosystem section style matches neighboring bullets
- [ ] Plugin directory tables unchanged